### PR TITLE
made dynamic_textH3 not push page layout in css

### DIFF
--- a/CSS/home.css
+++ b/CSS/home.css
@@ -1,6 +1,10 @@
 #dynamic_textH3 {
   text-align: center;
-  /* margin: auto; */
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  transform: translate(0, -10px);
 }
 
 


### PR DESCRIPTION
Added position absolute of dynamic text in home.css. Now the text won't make the layout shift down as text appears and disappears